### PR TITLE
use parentheses to remove ambiguity in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule PhoenixCalendar.Mixfile do
     [app: :phoenix_calendar,
      version: @version,
      elixir: "~> 1.0",
-     package: package,
+     package: package(),
      description: "Integration between Phoenix & Calendar",
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
with Elixir 1.4 I got this error

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /my_app/deps/phoenix_calendar/mix.exs:10
```
